### PR TITLE
Hardcoded 'Enter the test' replaced by string resource 'Enter the Text'.

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -43,7 +43,7 @@
         <com.google.android.material.textfield.TextInputEditText
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Enter the test" />
+            android:hint="@string/string1" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="menu_send">Send</string>
     <string name="facebook_application_id">435448930457946</string>
     <string name="fb_login_protocol_scheme">fb435448930457946</string>
+    <string name="string1">Enter the Text</string>
 </resources>


### PR DESCRIPTION
fixes #31 